### PR TITLE
Removed override for createJSModules

### DIFF
--- a/android/src/main/java/com/tectiv3/aes/RCTAesPackage.java
+++ b/android/src/main/java/com/tectiv3/aes/RCTAesPackage.java
@@ -21,11 +21,6 @@ public class RCTAesPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList();
     }


### PR DESCRIPTION
Removed override for createJSModules as this method has been removed from React Native version 0.47.0.