### PR TITLE
Export module from JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,26 @@ AES encryption/decryption for react-native
 
 ## Installation
 ```sh
-npm install --save react-native-aes-crypto
+npm install react-native-aes-crypto
 ```
-### Installation (iOS)
+or
+```sh
+yarn add react-native-aes-crypto
+```
+### Linking Automatically
+```sh
+react-native link
+```
+### Linking Manually
+
+#### iOS
 * See [Linking Libraries](http://facebook.github.io/react-native/docs/linking-libraries-ios.html)
 OR
 * Drag RCTAes.xcodeproj to your project on Xcode.
 * Click on your main project file (the one that represents the .xcodeproj) select Build Phases and drag libRCTAes.a from the Products folder inside the RCTAes.xcodeproj.
 
-### Installation (Android)
-#### Untested!
+#### (Android)
+##### Untested!
 ```gradle
 ...
 include ':react-native-aes'
@@ -51,9 +61,8 @@ protected List<ReactPackage> getPackages() {
 ### Example
 
 ```js
-import { NativeModules, Platform } from 'react-native';
-var Aes = NativeModules.Aes;
-
+import { Platform } from 'react-native';
+import Aes from 'react-native-aes-crypto'
 
 const generateKey = (password, salt) => Aes.pbkdf2(password, salt);
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 'use strict';
 import { NativeModules } from 'react-native';
-export const Aes = NativeModules.Aes;
+export default NativeModules.Aes;

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 'use strict';
 import { NativeModules } from 'react-native';
+export const Aes = NativeModules.Aes;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-aes-crypto",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "AES crypto native module for react-native",
     "main": "index.js",
     "author": "tectiv3",


### PR DESCRIPTION
* Exported module from JS main. Enabled `import Aes from 'react-native-aes-crypto'`
* Added Yarn installation (and fixed for modern npm)
* Added automatic linking instructions
* Updated examples
* Bumped version to 1.2.1