### PR TITLE
Fix toHex to work on iOS 13

### DIFF
--- a/ios/RCTAes/lib/AesCrypt.m
+++ b/ios/RCTAes/lib/AesCrypt.m
@@ -14,10 +14,12 @@
 @implementation AesCrypt
 
 + (NSString *) toHex:(NSData *)nsdata {
-    NSString * hexStr = [NSString stringWithFormat:@"%@", nsdata];
-    for(NSString * toRemove in [NSArray arrayWithObjects:@"<", @">", @" ", nil])
-        hexStr = [hexStr stringByReplacingOccurrencesOfString:toRemove withString:@""];
-    return hexStr;
+    const unsigned char *bytes = (const unsigned char *)nsdata.bytes;
+    NSMutableString *hex = [NSMutableString new];
+    for (NSInteger i = 0; i < nsdata.length; i++) {
+        [hex appendFormat:@"%02x", bytes[i]];
+    }
+    return [hex copy];
 }
 
 + (NSData *) fromHex: (NSString *)string {


### PR DESCRIPTION
Previously this function relied on NSData string presentation containing the whole hex-formatted data but iOS 13 has changed the output format to be like `{length=64,bytes=0xd192353225cd7ba54e650deaa321beab...a8c5f91828943709}`

This change copies the data byte-byte to formatted NSMutableString instead.