### PR TITLE
Improve import & types support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import com.tectiv3.aes.RCTAesPackage;
 protected List<ReactPackage> getPackages() {
    ......
    new RCTAesPackage(),
-   // or 
+   // or
    // packages.add(new RCTAesPackage());
    ......
 }
@@ -75,7 +75,7 @@ protected List<ReactPackage> getPackages() {
 
 ```js
 import { NativeModules, Platform } from 'react-native'
-var Aes = NativeModules.Aes
+import Aes from 'react-native-aes-crypto'
 
 const generateKey = (password, salt, cost, length) => Aes.pbkdf2(password, salt, cost, length)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module '@tectiv3/react-native-aes-crypto' {
+declare module 'react-native-aes-crypto' {
     function pbkdf2(password: string, salt: string, cost: number, length: number): Promise<string>;
     function encrypt(text: string, key: string, iv: string): Promise<string>;
     function decrypt(ciphertext: string, key: string, iv: string): Promise<string>;

--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
 'use strict';
 import { NativeModules } from 'react-native';
+
+export default NativeModules.Aes;


### PR DESCRIPTION
This is a breaking change!
If we import NativeModule for the users, they will be able to use types directly. Also using regular es6 import is possible.