### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-aes.podspec
+++ b/react-native-aes.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.platform      = :ios, '9.0'
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build without `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116