### PR TITLE
Adding HMAC-SHA-512

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ async function asyncDecrypt(cipher, key, iv) {
 -   `decrypt(base64, key, iv)`
 -   `pbkdf2(text, salt, cost, length)`
 -   `hmac256(cipher, key)`
+-   `hmac512(cipher, key)`
 -   `sha1(text)`
 -   `sha256(text)`
 -   `sha512(text)`

--- a/android/src/main/java/com/tectiv3/aes/RCTAes.java
+++ b/android/src/main/java/com/tectiv3/aes/RCTAes.java
@@ -42,6 +42,7 @@ public class RCTAes extends ReactContextBaseJavaModule {
 
     private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS7Padding";
     public static final String HMAC_SHA_256 = "HmacSHA256";
+    public static final String HMAC_SHA_512 = "HmacSHA512";
     private static final String KEY_ALGORITHM = "AES";
 
     public RCTAes(ReactApplicationContext reactContext) {
@@ -87,6 +88,16 @@ public class RCTAes extends ReactContextBaseJavaModule {
     public void hmac256(String data, String pwd, Promise promise) {
         try {
             String strs = hmac256(data, pwd);
+            promise.resolve(strs);
+        } catch (Exception e) {
+            promise.reject("-1", e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void hmac512(String data, String pwd, Promise promise) {
+        try {
+            String strs = hmac512(data, pwd);
             promise.resolve(strs);
         } catch (Exception e) {
             promise.reject("-1", e.getMessage());
@@ -182,6 +193,17 @@ public class RCTAes extends ReactContextBaseJavaModule {
         SecretKey secret_key = new SecretKeySpec(akHexData, HMAC_SHA_256);
         sha256_HMAC.init(secret_key);
         return bytesToHex(sha256_HMAC.doFinal(contentData));
+    }
+
+    private static String hmac512(String text, String key)
+    throws NoSuchAlgorithmException, InvalidKeyException, UnsupportedEncodingException
+    {
+        byte[] contentData = text.getBytes("UTF_8");
+        byte[] akHexData = Hex.decode(key);
+        Mac sha512_HMAC = Mac.getInstance(HMAC_SHA_512);
+        SecretKey secret_key = new SecretKeySpec(akHexData, HMAC_SHA_512);
+        sha512_HMAC.init(secret_key);
+        return bytesToHex(sha512_HMAC.doFinal(contentData));
     }
 
     final static IvParameterSpec emptyIvSpec = new IvParameterSpec(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});

--- a/android/src/main/java/com/tectiv3/aes/RCTAes.java
+++ b/android/src/main/java/com/tectiv3/aes/RCTAes.java
@@ -87,7 +87,7 @@ public class RCTAes extends ReactContextBaseJavaModule {
     @ReactMethod
     public void hmac256(String data, String pwd, Promise promise) {
         try {
-            String strs = hmac256(data, pwd);
+            String strs = hmacX(data, pwd, HMAC_SHA_256);
             promise.resolve(strs);
         } catch (Exception e) {
             promise.reject("-1", e.getMessage());
@@ -97,7 +97,7 @@ public class RCTAes extends ReactContextBaseJavaModule {
     @ReactMethod
     public void hmac512(String data, String pwd, Promise promise) {
         try {
-            String strs = hmac512(data, pwd);
+            String strs = hmacX(data, pwd, HMAC_SHA_512);
             promise.resolve(strs);
         } catch (Exception e) {
             promise.reject("-1", e.getMessage());
@@ -184,26 +184,15 @@ public class RCTAes extends ReactContextBaseJavaModule {
         return bytesToHex(key);
     }
 
-    private static String hmac256(String text, String key)
+    private static String hmacX(String text, String key, String algorithm)
     throws NoSuchAlgorithmException, InvalidKeyException, UnsupportedEncodingException
     {
         byte[] contentData = text.getBytes("UTF_8");
         byte[] akHexData = Hex.decode(key);
-        Mac sha256_HMAC = Mac.getInstance(HMAC_SHA_256);
-        SecretKey secret_key = new SecretKeySpec(akHexData, HMAC_SHA_256);
-        sha256_HMAC.init(secret_key);
-        return bytesToHex(sha256_HMAC.doFinal(contentData));
-    }
-
-    private static String hmac512(String text, String key)
-    throws NoSuchAlgorithmException, InvalidKeyException, UnsupportedEncodingException
-    {
-        byte[] contentData = text.getBytes("UTF_8");
-        byte[] akHexData = Hex.decode(key);
-        Mac sha512_HMAC = Mac.getInstance(HMAC_SHA_512);
-        SecretKey secret_key = new SecretKeySpec(akHexData, HMAC_SHA_512);
-        sha512_HMAC.init(secret_key);
-        return bytesToHex(sha512_HMAC.doFinal(contentData));
+        Mac sha_HMAC = Mac.getInstance(algorithm);
+        SecretKey secret_key = new SecretKeySpec(akHexData, algorithm);
+        sha_HMAC.init(secret_key);
+        return bytesToHex(sha_HMAC.doFinal(contentData));
     }
 
     final static IvParameterSpec emptyIvSpec = new IvParameterSpec(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ declare module '@tectiv3/react-native-aes-crypto' {
     function encrypt(text: string, key: string, iv: string): Promise<string>;
     function decrypt(ciphertext: string, key: string, iv: string): Promise<string>;
     function hmac256(ciphertext: string, key: string): Promise<string>;
+    function hmac512(ciphertext: string, key: string): Promise<string>;
     function randomKey(length: number): Promise<string>;
     function sha1(text: string): Promise<string>;
     function sha256(text: string): Promise<string>;

--- a/ios/RCTAes/RCTAes.m
+++ b/ios/RCTAes/RCTAes.m
@@ -63,6 +63,18 @@ RCT_EXPORT_METHOD(hmac256:(NSString *)base64 key:(NSString *)key
     }
 }
 
+RCT_EXPORT_METHOD(hmac512:(NSString *)base64 key:(NSString *)key
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSError *error = nil;
+    NSString *data = [AesCrypt hmac512:base64 key:key];
+    if (data == nil) {
+        reject(@"hmac_fail", @"HMAC error", error);
+    } else {
+        resolve(data);
+    }
+}
+
 RCT_EXPORT_METHOD(sha1:(NSString *)text
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {

--- a/ios/RCTAes/lib/AesCrypt.h
+++ b/ios/RCTAes/lib/AesCrypt.h
@@ -12,6 +12,7 @@
 + (NSString *) decrypt: (NSString *)cipherText key: (NSString *)key iv: (NSString *)iv;
 + (NSString *) pbkdf2:(NSString *)password salt: (NSString *)salt cost: (NSInteger)cost length: (NSInteger)length;
 + (NSString *) hmac256: (NSString *)input key: (NSString *)key;
++ (NSString *) hmac512: (NSString *)input key: (NSString *)key;
 + (NSString *) sha1: (NSString *)input;
 + (NSString *) sha256: (NSString *)input;
 + (NSString *) sha512: (NSString *)input;

--- a/ios/RCTAes/lib/AesCrypt.m
+++ b/ios/RCTAes/lib/AesCrypt.m
@@ -109,6 +109,15 @@
     return [self toHex:nsdata];
 }
 
++ (NSString *) hmac512: (NSString *)input key: (NSString *)key {
+    NSData *keyData = [self fromHex:key];
+    NSData* inputData = [input dataUsingEncoding:NSUTF8StringEncoding];
+    void* buffer = malloc(CC_SHA512_DIGEST_LENGTH);
+    CCHmac(kCCHmacAlgSHA512, [keyData bytes], [keyData length], [inputData bytes], [inputData length], buffer);
+    NSData *nsdata = [NSData dataWithBytesNoCopy:buffer length:CC_SHA512_DIGEST_LENGTH freeWhenDone:YES];
+    return [self toHex:nsdata];
+}
+
 + (NSString *) sha1: (NSString *)input {
     NSData* inputData = [input dataUsingEncoding:NSUTF8StringEncoding];
     NSMutableData *result = [[NSMutableData alloc] initWithLength:CC_SHA1_DIGEST_LENGTH];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "sha512",
         "pbkdf2",
         "hmac256",
+        "hmac512",
         "uuid"
     ],
     "homepage": "https://github.com/tectiv3/react-native-aes",


### PR DESCRIPTION
HMAC-SHA-512 is used to implement authenticated encryption with AES-256-CBC according to 2.7 of this draft: https://tools.ietf.org/html/draft-mcgrew-aead-aes-cbc-hmac-sha2-05. The output will be truncated to the first half and is then used for the authentication.
From what I've seen in the commit history, the library was originally implemented with AES-128-CBC and HMAC-256, which in combination also corresponds to the draft.
Since commit https://github.com/tectiv3/react-native-aes/commit/0b70513b5c80a14cd52658492cef752fe3c7118d, where the encrypt and decrypt methods were upgraded to AES-256, no HMAC-512 method was implemented. This is what I would like to contribute with my pull request.