### PR TITLE
Fix: update podspec to retrieve source via git tag

### DIFF
--- a/react-native-aes.podspec
+++ b/react-native-aes.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license       = 'MIT'
   s.requires_arc  = true
   s.homepage      = "https://github.com/tectiv3/react-native-aes"
-  s.source        = { :git => 'https://github.com/tectiv3/react-native-aes' }
+  s.source        = { :git => 'https://github.com/tectiv3/react-native-aes', :tag => 'v#{s.version}' }
   s.platform      = :ios, '9.0'
   s.source_files  = "ios/**/*.{h,m}"
 

--- a/react-native-aes.podspec
+++ b/react-native-aes.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license       = 'MIT'
   s.requires_arc  = true
   s.homepage      = "https://github.com/tectiv3/react-native-aes"
-  s.source        = { :git => 'https://github.com/tectiv3/react-native-aes', :tag => 'v#{s.version}' }
+  s.source        = { :git => 'https://github.com/tectiv3/react-native-aes', :tag => "v#{s.version}" }
   s.platform      = :ios, '9.0'
   s.source_files  = "ios/**/*.{h,m}"
 


### PR DESCRIPTION
The source in the .podspec file is pointing to the latest commits instead of the commit specific to the version.. This change adds the tag of the release to make the source more specific.

# How to verify:
1. Create a new project with an older version of the package (e.g. 1.3.8) and use either `Aes.encrypt` or `Aes.decrypt` with only the 3 arguments that was previously required (as shown in README)
2. Add the pod to the project's podspec:
```
pod 'react-native-app-auth', :podspec => '../node_modules/react-native-app-auth/react-native-app-auth.podspec'
```
3. `pod install`
4. Verify the following error shows up:
![image](https://user-images.githubusercontent.com/15166670/130622015-c8a676ca-42bb-495f-8564-d4817ab6f250.png)
5. Apply suggested changes
6. Ensure error no longer occurs