### PR TITLE
fixed index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,13 @@
 declare module 'react-native-aes-crypto' {
-    namespace Aes {
-        type Algorithms = 'aes-128-cbc' | 'aes-192-cbc' | 'aes-256-cbc'
+    type Algorithms = 'aes-128-cbc' | 'aes-192-cbc' | 'aes-256-cbc'
 
-        function pbkdf2(password: string, salt: string, cost: number, length: number): Promise<string>
-        function encrypt(text: string, key: string, iv: string, algorithm: Algorithms): Promise<string>
-        function decrypt(ciphertext: string, key: string, iv: string, algorithm: Algorithms): Promise<string>
-        function hmac256(ciphertext: string, key: string): Promise<string>
-        function hmac512(ciphertext: string, key: string): Promise<string>
-        function randomKey(length: number): Promise<string>
-        function sha1(text: string): Promise<string>
-        function sha256(text: string): Promise<string>
-        function sha512(text: string): Promise<string>
-    }
+    function pbkdf2(password: string, salt: string, cost: number, length: number): Promise<string>
+    function encrypt(text: string, key: string, iv: string, algorithm: Algorithms): Promise<string>
+    function decrypt(ciphertext: string, key: string, iv: string, algorithm: Algorithms): Promise<string>
+    function hmac256(ciphertext: string, key: string): Promise<string>
+    function hmac512(ciphertext: string, key: string): Promise<string>
+    function randomKey(length: number): Promise<string>
+    function sha1(text: string): Promise<string>
+    function sha256(text: string): Promise<string>
+    function sha512(text: string): Promise<string>
 }


### PR DESCRIPTION
The types aren't working (Tested IntelliJ and Visual Studio Code) in the way `index.d.ts` was defined. It would have been supported as 
```
import { Aes } from 'react-native-aes-crypto';
```
but the code actually require it to be 
```
import Aes from 'react-native-aes-crypto';
```
(as the documentation states as well).