### PR TITLE
feat: add visionOS support

### DIFF
--- a/react-native-aes.podspec
+++ b/react-native-aes.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.homepage      = "https://github.com/tectiv3/react-native-aes"
   s.source        = { :git => 'https://github.com/tectiv3/react-native-aes', :tag => "v#{s.version}" }
-  s.platform      = :ios, '9.0'
+  s.platforms     = { :ios => "9.0", :visionos => "1.0" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency "React-Core"


### PR DESCRIPTION
Add support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

This only adds a new platform to the podspec, so the module can be installed in visionOS. No changes to any existing functionality.

https://github.com/tectiv3/react-native-aes/assets/26878038/4d45447f-f16f-4159-bee8-cb8cbee3d16d