### PR TITLE
Fixes runtime error where module is `null`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict'
 import { NativeModules } from 'react-native'
 
-export default NativeModules.Aes
+export default NativeModules.RCTAes


### PR DESCRIPTION
Solves runtime issue where `NativeModules.Aes` is `null` on Android as reported by https://github.com/tectiv3/react-native-aes/issues/92 and https://github.com/tectiv3/react-native-aes/issues/89.

`NativeModules.RCTAes` seems to work as expected on Android using RN 0.76 (with Expo 52, Turbo Modules and Fabric enabled), and also on iOS.